### PR TITLE
docs: Fix 2.x installation raw links

### DIFF
--- a/docs/installation/INSTALL.md
+++ b/docs/installation/INSTALL.md
@@ -11,10 +11,10 @@ It covers both upgrade paths:
 Ask your assistant to:
 
 ```text
-Fetch and follow instructions from https://raw.githubusercontent.com/truecms/design-system-components/refs/heads/main/docs/installation/INSTRUCTIONS.md
+Fetch and follow instructions from https://raw.githubusercontent.com/truecms/design-system-components/refs/heads/2.x/docs/installation/INSTRUCTIONS.md
 ```
 
-If you need branch-specific instructions before merge (for example `feature/d11`), replace `main` in the URL with your branch name.
+If you need branch-specific instructions before merge (for example `feature/d11`), replace `2.x` in the URL with your branch name.
 
 ## Required migration inputs
 

--- a/docs/installation/claude/INSTALL.md
+++ b/docs/installation/claude/INSTALL.md
@@ -3,7 +3,7 @@
 Use the canonical installation entrypoint in this repository:
 
 ```text
-Fetch and follow instructions from https://raw.githubusercontent.com/truecms/design-system-components/refs/heads/main/docs/installation/INSTALL.md
+Fetch and follow instructions from https://raw.githubusercontent.com/truecms/design-system-components/refs/heads/2.x/docs/installation/INSTALL.md
 ```
 
-If you need branch-specific instructions before merge (for example `feature/d11`), replace `main` in the URL with that branch name.
+If you need branch-specific instructions before merge (for example `feature/d11`), replace `2.x` in the URL with that branch name.

--- a/docs/installation/codex/INSTALL.md
+++ b/docs/installation/codex/INSTALL.md
@@ -3,7 +3,7 @@
 Use the canonical installation entrypoint in this repository:
 
 ```text
-Fetch and follow instructions from https://raw.githubusercontent.com/truecms/design-system-components/refs/heads/main/docs/installation/INSTALL.md
+Fetch and follow instructions from https://raw.githubusercontent.com/truecms/design-system-components/refs/heads/2.x/docs/installation/INSTALL.md
 ```
 
-If you need branch-specific instructions before merge (for example `feature/d11`), replace `main` in the URL with that branch name.
+If you need branch-specific instructions before merge (for example `feature/d11`), replace `2.x` in the URL with that branch name.

--- a/docs/installation/cursor/INSTALL.md
+++ b/docs/installation/cursor/INSTALL.md
@@ -3,7 +3,7 @@
 Use the canonical installation entrypoint in this repository:
 
 ```text
-Fetch and follow instructions from https://raw.githubusercontent.com/truecms/design-system-components/refs/heads/main/docs/installation/INSTALL.md
+Fetch and follow instructions from https://raw.githubusercontent.com/truecms/design-system-components/refs/heads/2.x/docs/installation/INSTALL.md
 ```
 
-If you need branch-specific instructions before merge (for example `feature/d11`), replace `main` in the URL with that branch name.
+If you need branch-specific instructions before merge (for example `feature/d11`), replace `2.x` in the URL with that branch name.

--- a/docs/installation/opencode/INSTALL.md
+++ b/docs/installation/opencode/INSTALL.md
@@ -3,7 +3,7 @@
 Use the canonical installation entrypoint in this repository:
 
 ```text
-Fetch and follow instructions from https://raw.githubusercontent.com/truecms/design-system-components/refs/heads/main/docs/installation/INSTALL.md
+Fetch and follow instructions from https://raw.githubusercontent.com/truecms/design-system-components/refs/heads/2.x/docs/installation/INSTALL.md
 ```
 
-If you need branch-specific instructions before merge (for example `feature/d11`), replace `main` in the URL with that branch name.
+If you need branch-specific instructions before merge (for example `feature/d11`), replace `2.x` in the URL with that branch name.


### PR DESCRIPTION
## Summary
- replace stale `refs/heads/main` installation links with `refs/heads/2.x`
- update branch-override guidance text to replace `2.x` (instead of `main`)
- keep install entrypoints aligned across assistant-specific docs

## Problem
Installation docs on `2.x` referenced `main` branch raw URLs, which return 404 for this repository.

## Validation
- `rg "refs/heads/main/docs/installation" docs README.md` returns no matches after changes
- branch pushed to origin for review
