### PR TITLE
fix: pass release args to changesets correctly

### DIFF
--- a/.changeset/unified-package-single-install-govcms.md
+++ b/.changeset/unified-package-single-install-govcms.md
@@ -1,5 +1,0 @@
----
-"@truecms/design-system": minor
----
-
-Expand the unified design-system package so a GovCMS UI-Kit consumer can install a single `@truecms/design-system` dependency and still resolve the full Drupal starter theme package surface during build and tarball install verification. Also broaden the Drupal CSS entrypoints to build from source dependency entrypoints in a clean checkout.

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -191,16 +191,16 @@ jobs:
             args+=(--dry-run)
           fi
 
-          echo "Running: pnpm run release -- ${args[*]}"
+          echo "Running: pnpm run release ${args[*]}"
           set +e
-          pnpm run release -- "${args[@]}" | tee changesets-publish.log
+          pnpm run release ${args[@]} | tee changesets-publish.log
           status=$?
           set -e
 
           if grep -qiE "No packages are being published|No unpublished packages found" changesets-publish.log; then
             echo "::notice::No release plan detected. Retrying with --from-package."
             echo "Running: pnpm changeset publish --from-package ${args[*]}"
-            pnpm changeset publish --from-package "${args[@]}"
+            pnpm changeset publish --from-package ${args[@]}
           else
             exit "$status"
           fi

--- a/packages/unified-design-system/CHANGELOG.md
+++ b/packages/unified-design-system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @truecms/design-system
 
+## 1.1.0
+
+### Minor Changes
+
+- c7b0708: Expand the unified design-system package so a GovCMS UI-Kit consumer can install a single `@truecms/design-system` dependency and still resolve the full Drupal starter theme package surface during build and tarball install verification. Also broaden the Drupal CSS entrypoints to build from source dependency entrypoints in a clean checkout.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/unified-design-system/package.json
+++ b/packages/unified-design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truecms/design-system",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Unified GovAU design system package for Drupal and React consumers.",
   "keywords": [
     "auds",

--- a/packages/unified-design-system/package.json
+++ b/packages/unified-design-system/package.json
@@ -10,6 +10,10 @@
     "drupal",
     "react"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/truecms/design-system-components"
+  },
   "main": "dist/js/components.js",
   "module": "dist/js/components.js",
   "types": "dist/js/components.d.ts",


### PR DESCRIPTION
## Summary
- fix the npm Release workflow so Changesets receives `--tag` / `--dry-run` arguments correctly
- avoid passing a stray literal `--` through to `changeset publish`, which caused the publish step to no-op even when the workflow otherwise reported success

## Verification
- triggered `npm Release` from this branch with `dist_tag=beta` and `dry_run=false` to validate the corrected publish path

## Notes
- No issue-closing reference is applicable.
