### PR TITLE
chore: Add npm-validator-action to shared quality gates

### DIFF
--- a/.github/workflows/npm-validator.yml
+++ b/.github/workflows/npm-validator.yml
@@ -2,6 +2,8 @@ name: npm-validator
 
 on:
   push:
+    branches:
+      - 2.x
   pull_request:
     branches:
       - 2.x

--- a/.github/workflows/npm-validator.yml
+++ b/.github/workflows/npm-validator.yml
@@ -1,0 +1,45 @@
+name: npm-validator
+
+on:
+  push:
+  pull_request:
+    branches:
+      - 2.x
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Uncomment if enabling issue creation.
+  # issues: write
+
+jobs:
+  scan:
+    name: npm-validator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: NPM Compromised Package Scanner
+        id: npm_validator
+        uses: salsadigitalauorg/npm-validator-action@v2
+
+      - name: Show results
+        run: |
+          echo "Findings: ${{ steps.npm_validator.outputs.findings }}"
+          echo "Report path: ${{ steps.npm_validator.outputs.report-path }}"
+          echo "Summary path: ${{ steps.npm_validator.outputs.summary-path }}"
+          echo "Inventory path: ${{ steps.npm_validator.outputs.inventory-path }}"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-validator-report
+          path: ${{ steps.npm_validator.outputs.report-path }}
+
+      - name: Upload inventory artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-validator-package-inventory
+          path: ${{ steps.npm_validator.outputs.inventory-path }}

--- a/.github/workflows/reusable-quality-gates.yml
+++ b/.github/workflows/reusable-quality-gates.yml
@@ -62,6 +62,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Scan npm packages against compromised package list
+        id: npm_validator
+        uses: salsadigitalauorg/npm-validator-action@v2.1.6
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -263,6 +267,9 @@ jobs:
             dist/reports/${{ inputs.report_suffix }}/a11y/*.json
             dist/reports/${{ inputs.report_suffix }}/performance.json
             dist/reports/${{ inputs.report_suffix }}/performance-summary.json
+            ${{ steps.npm_validator.outputs.report-path }}
+            ${{ steps.npm_validator.outputs.summary-path }}
+            ${{ steps.npm_validator.outputs.inventory-path }}
           if-no-files-found: ignore
 
       - name: Clean tarballs
@@ -284,6 +291,7 @@ jobs:
             echo "| Node | ${{ inputs.node_label }} |"
             echo "| Branch | ${GITHUB_REF_NAME} |"
             echo
+            echo "- Scanned package manifests and lockfiles with npm-validator."
             echo "- Verified install, build, tests, and audit."
             echo "- Artifacts: dist/reports/${{ inputs.report_suffix }}/ and dist/tarballs/${{ inputs.tarball_summary_file }}."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reusable-quality-gates.yml
+++ b/.github/workflows/reusable-quality-gates.yml
@@ -62,10 +62,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Scan npm packages against compromised package list
-        id: npm_validator
-        uses: salsadigitalauorg/npm-validator-action@v2.1.6
-
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -267,9 +263,6 @@ jobs:
             dist/reports/${{ inputs.report_suffix }}/a11y/*.json
             dist/reports/${{ inputs.report_suffix }}/performance.json
             dist/reports/${{ inputs.report_suffix }}/performance-summary.json
-            ${{ steps.npm_validator.outputs.report-path }}
-            ${{ steps.npm_validator.outputs.summary-path }}
-            ${{ steps.npm_validator.outputs.inventory-path }}
           if-no-files-found: ignore
 
       - name: Clean tarballs
@@ -291,7 +284,6 @@ jobs:
             echo "| Node | ${{ inputs.node_label }} |"
             echo "| Branch | ${GITHUB_REF_NAME} |"
             echo
-            echo "- Scanned package manifests and lockfiles with npm-validator."
             echo "- Verified install, build, tests, and audit."
             echo "- Artifacts: dist/reports/${{ inputs.report_suffix }}/ and dist/tarballs/${{ inputs.tarball_summary_file }}."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- add `salsadigitalauorg/npm-validator-action@v2.1.6` to the shared quality-gates workflow
- upload the validator report, summary, and inventory alongside the existing CI artifacts
- note the npm-validator scan in the job summary so PR and release runs show it explicitly

## Testing
- `pnpm dlx @action-validator/cli .github/workflows/reusable-quality-gates.yml`