### PR TITLE
chore: Add npm-validator workflow

### DIFF
--- a/.github/workflows/npm-validator.yml
+++ b/.github/workflows/npm-validator.yml
@@ -1,0 +1,47 @@
+name: npm-validator
+
+on:
+  push:
+    branches:
+      - 2.x
+  pull_request:
+    branches:
+      - 2.x
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Uncomment if enabling issue creation.
+  # issues: write
+
+jobs:
+  scan:
+    name: npm-validator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: NPM Compromised Package Scanner
+        id: npm_validator
+        uses: salsadigitalauorg/npm-validator-action@v2
+
+      - name: Show results
+        run: |
+          echo "Findings: ${{ steps.npm_validator.outputs.findings }}"
+          echo "Report path: ${{ steps.npm_validator.outputs.report-path }}"
+          echo "Summary path: ${{ steps.npm_validator.outputs.summary-path }}"
+          echo "Inventory path: ${{ steps.npm_validator.outputs.inventory-path }}"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-validator-report
+          path: ${{ steps.npm_validator.outputs.report-path }}
+
+      - name: Upload inventory artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-validator-package-inventory
+          path: ${{ steps.npm_validator.outputs.inventory-path }}


### PR DESCRIPTION
## Summary
- add a dedicated `npm-validator` workflow based on the install prompt from the `npm-validator` repository
- use `salsadigitalauorg/npm-validator-action@v2` in its own workflow file
- restrict `push` to `2.x` so feature branch updates with an open PR do not run the workflow twice

## Testing
- `pnpm dlx @action-validator/cli .github/workflows/npm-validator.yml`